### PR TITLE
Update read.luau to yield for callback (query.invoke())

### DIFF
--- a/src/process/read.luau
+++ b/src/process/read.luau
@@ -43,6 +43,7 @@ end
 
 local function runQueryListener(callback, listenOnce: boolean, query, ...)
 	local result 
+	local ts = tick();
 	if freeThread == nil then
 		freeThread = coroutine.create(yielder)
 		coroutine.resume(freeThread :: thread)
@@ -51,6 +52,14 @@ local function runQueryListener(callback, listenOnce: boolean, query, ...)
 	task.spawn(freeThread :: thread, function(...)
 		result = callback(...)
 	end, ...)
+	
+	repeat
+		task.wait()
+	until result or (tick() - ts) > 10;
+	
+	if not result then
+		warn("queryResult hung for 10 seconds, returning null.")
+	end
 	
 	if listenOnce then
 		query.disconnect(callback)


### PR DESCRIPTION
Currently query.invoke() does not yield as reported here : 
https://devforum.roblox.com/t/bytenet-max-upgraded-networking-library-w-buffer-serialisation-strict-luau-and-remotefunction-support-v018/3268469/33

I added a 10 second tick() based time-out and a repeat task.wait() until the result is resolved or the timeout is reached.
Query.invoke() is currently broken without some kind of yield by the way, any small yield (even server lag) and the query dies.