### PR TITLE
Removed print function clogging up console

### DIFF
--- a/src/process/bufferWriter.luau
+++ b/src/process/bufferWriter.luau
@@ -77,7 +77,6 @@ function bufferWriter.reference(value: any)
 
 	buffer.writeu8(buff, cursor, index)
 	cursor += 1
-	print(references)
 end
 
 function bufferWriter.u16(value: number)


### PR DESCRIPTION
Unnecessary print caused console to clog up. Removed since this shouldn't be present in the main branch.