### PR TITLE
fix 10s hang when a query result returns false

### DIFF
--- a/src/process/read.luau
+++ b/src/process/read.luau
@@ -55,7 +55,7 @@ local function runQueryListener(callback, listenOnce: boolean, query, ...)
 	
 	repeat
 		task.wait()
-	until result or (tick() - ts) > 10;
+	until result ~= nil or (tick() - ts) > 10;
 	
 	if result == nil then
 		warn("queryResult hung for 10 seconds, returning null.")

--- a/src/process/server.luau
+++ b/src/process/server.luau
@@ -11,7 +11,7 @@ local alloc = bufferWriter.alloc
 local u8 = bufferWriter.u8
 local load = bufferWriter.load
 
-local MAX_BUFFER_SIZE = math.floor(script.Parent.Parent:GetAttribute("MAX_BUFFER_SIZE"))
+local MAX_BUFFER_SIZE = math.floor(script.Parent.Parent:GetAttribute("MAX_BUFFER_SIZE") or 4096)
 local rateLimit = {
 	bytesPerSec = MAX_BUFFER_SIZE,
 	refillRate = MAX_BUFFER_SIZE,


### PR DESCRIPTION
Using a non-struct as a packet body or response appears to be valid in ByteNet, but if a query returns false and nothing else, it shouldn't hang for 10 seconds really