### PR TITLE
fix listenOnce being extremely broken (and a minor query issue)

### DIFF
--- a/src/packets/packet.luau
+++ b/src/packets/packet.luau
@@ -16,7 +16,7 @@ local moduleRunContext: "server" | "client" = if RunService:IsServer() then "ser
 return function(props: types.packetProps<types.dataTypeInterface<any>>, id: number)
 	-- Basic properties: reliability type, "unique" which is used to get the packet ID, and set up listeners
 	local reliabilityType = props.reliabilityType or "reliable"
-	local listeners = {}
+	local listeners: {types.Listener<any>} = {} 
 
 	local serverSendFunction: (player: Player, id: number, writer: (value: any) -> (), data: any) -> () = if reliabilityType
 			== "reliable"
@@ -84,29 +84,29 @@ return function(props: types.packetProps<types.dataTypeInterface<any>>, id: numb
 	end
 
 	function exported.wait()
-		-- define it up here so we can use it to disconnect
-		local index: number
-
+		-- use a OnceCallback to resume the thread
 		local runningThread = coroutine.running()
-		table.insert(listeners, function(data, player)
-			task.spawn(runningThread, data, player)
+		table.insert(listeners, { 
+			Callback  = function(data, player)
+				task.spawn(runningThread, data, player)
+			end,
+			OnceCallback = true
+		})
 
-			-- Disconnects the listener
-			table.remove(listeners, index)
-		end)
-
-		-- we connected, time to set the index for when we need to disconnect.
-		index = #listeners
 
 		-- the listener will resume the thread
 		return coroutine.yield()
 	end
 
 	function exported.listen(callback)
-		table.insert(listeners, callback)
+		local listener = {
+			Callback = callback,
+			OnceCallback = false
+		}
+		table.insert(listeners, listener)
 		
 		return function()
-			exported.disconnect(callback)
+			exported.disconnect(listener)
 		end
 	end
 	
@@ -114,14 +114,26 @@ return function(props: types.packetProps<types.dataTypeInterface<any>>, id: numb
 		table.clear(listeners)
 	end
 	
-	function exported.disconnect(callback)
-		table.remove(listeners, table.find(listeners, callback))
+	function exported.disconnect(listener)
+		-- Ensure the index isn't nil to avoid removing arbitrary listeners
+		local index = table.find(listeners, listener)
+		if index ~= nil then
+			table.remove(listeners, index)
+		else
+			warn('Packet listener was already disconnected.')
+		end
 	end
 	
 	function exported.listenOnce(callback)
-		table.insert(listeners, {
-			["OnceCallback"] = callback	
-		})
+		local listener =  {
+			Callback = callback,
+			OnceCallback = true	
+		}
+		table.insert(listeners, listener)
+
+		return function()
+			exported.disconnect(listener)
+		end
 	end
 	
 	function exported.getListeners()

--- a/src/process/read.luau
+++ b/src/process/read.luau
@@ -29,20 +29,18 @@ local function yielder()
 	end
 end
 
-local function runListener(callback, listenOnce: boolean, packet, ...)
+local function runListener(listener, packet, ...)
 	if freeThread == nil then
 		freeThread = coroutine.create(yielder)
 		coroutine.resume(freeThread :: thread)
 	end
 
-	task.spawn(freeThread :: thread, callback, ...)
-	if listenOnce then
-		packet.disconnect(callback)
-	end
+	task.spawn(freeThread :: thread, listener.Callback, ...)
 end
 
-local function runQueryListener(callback, listenOnce: boolean, query, ...)
+local function runQueryListener(listener: types.QueryListener<any,any>, query, ...)
 	local result 
+	local callbackEnded: boolean = false
 	local ts = tick();
 	if freeThread == nil then
 		freeThread = coroutine.create(yielder)
@@ -59,10 +57,6 @@ local function runQueryListener(callback, listenOnce: boolean, query, ...)
 	
 	if callbackEnded == false then
 		warn("query hung for 10 seconds or otherwise failed, returning nil.")
-	end
-	
-	if listenOnce then
-		query.disconnect(callback)
 	end
 		
 	return result
@@ -84,6 +78,12 @@ local function dump(channel: types.channelData): (buffer, { unknown }?)
 	buffer.copy(dumpBuffer, 0, channel.buff, 0, cursor)
 
 	return dumpBuffer, if #channel.references > 0 then channel.references else nil
+end
+
+local function clearListeners(packetOrQuery, listeners: {types.Listener<any>})
+	for _, listener in listeners do
+		packetOrQuery.disconnect(listener)
+	end
 end
 
 return function(incomingBuffer: buffer, references: { [number]: unknown }?, player: Player?, readType: string?, id: number?)
@@ -125,25 +125,39 @@ return function(incomingBuffer: buffer, references: { [number]: unknown }?, play
 		
 		readCursor += valueLength
 
+		-- Triggered OnceCallback listeners to remove.
+		-- we can't remove them immediately as that causes
+		-- issues if we have multiple listeners to iterate
+		local listenersToDisconnect: {types.Listener<any>} = {}
+
 		if readType == "packet" then
 			for _, listener in readablePacketOrQuery.getListeners() do
 				if typeof(listener) == "table" then
-					runListener(listener["OnceCallback"], true, readablePacketOrQuery, value, player)
-				elseif typeof(listener) == "function" then
-					runListener(listener, false, readablePacketOrQuery, value, player)
+					runListener(listener, readablePacketOrQuery, value, player)
+
+					if listener.OnceCallback == true then
+						table.insert(listenersToDisconnect, listener)
+					end
 				else
 					error("Listener type not recognised for packet: " .. typeof(listener))
 				end
 			end
+			clearListeners(readablePacketOrQuery, listenersToDisconnect)
 		elseif readType == "query" then
 			if RunService:IsServer() then
 				for _, listener in readablePacketOrQuery.getListeners() do
 					local response 
 					
-					if typeof(listener) == "table" then
-						response = runQueryListener(listener["OnceCallback"], true, readablePacketOrQuery, value, player)
-					elseif typeof(listener) == "function" then
-						response = runQueryListener(listener, false, readablePacketOrQuery, value, player)
+					if typeof(listener) == "table" and listener.Disconnecting ~= true then
+						-- mark it as disconnecting so it doesn't get triggered twice
+						-- should the callback take a while and the packet is invoked
+						-- more than once.
+						if listener.OnceCallback == true then
+							listener.Disconnecting = true
+							table.insert(listenersToDisconnect, listener)
+						end
+
+						response = runQueryListener(listener, readablePacketOrQuery, value, player)
 					else
 						error("Listener type not recognised for query: " .. typeof(listener))
 					end
@@ -159,10 +173,13 @@ return function(incomingBuffer: buffer, references: { [number]: unknown }?, play
 										
 					if func.cursor > 0 then
 						local dumpBuffer, reference = dump(func)
-												
+
+						clearListeners(readablePacketOrQuery, listenersToDisconnect)
+						
 						return dumpBuffer, reference
 					end
-				end	
+				end
+				print('not returning ???')
 			elseif RunService:IsClient() then
 				return value
 			end

--- a/src/process/server.luau
+++ b/src/process/server.luau
@@ -11,7 +11,7 @@ local alloc = bufferWriter.alloc
 local u8 = bufferWriter.u8
 local load = bufferWriter.load
 
-local MAX_BUFFER_SIZE = math.floor(script.Parent.Parent:GetAttribute("MAX_BUFFER_SIZE") or 4096)
+local MAX_BUFFER_SIZE = math.floor(script.Parent.Parent:GetAttribute("MAX_BUFFER_SIZE") or 8192)
 local rateLimit = {
 	bytesPerSec = MAX_BUFFER_SIZE,
 	refillRate = MAX_BUFFER_SIZE,

--- a/src/queries/query.luau
+++ b/src/queries/query.luau
@@ -10,7 +10,7 @@ local server = require(script.Parent.Parent.process.server)
 local moduleRunContext: "server" | "client" = if RunService:IsServer() then "server" else "client"
 
 return function(properties: types.queryProperties<types.dataTypeInterface<any>, types.dataTypeInterface<any>>, id: number)
-	local listeners = {}
+	local listeners: {types.QueryListener<any, any>} = {}
 	
 	local clientInvokeFunction: (id: number, requestWriter: (value: any) -> (), data: any) -> any = client.invoke
 	
@@ -31,26 +31,28 @@ return function(properties: types.queryProperties<types.dataTypeInterface<any>, 
 	end
 	
 	function exported.wait()
-		local index: number
-		
+		-- use a OnceCallback for this still
 		local runningThread = coroutine.running()
-		table.insert(listeners, function(data, player)
-			print(data)
-			task.spawn(runningThread, data, player)
-			
-			table.remove(listeners, index)
-		end)
-		
-		index = #listeners
+		table.insert(listeners, {
+			Callback = function(data, player)
+				print(data)
+				task.spawn(runningThread, data, player)
+			end,
+			OnceCallback = true
+		})
 		
 		return coroutine.yield()
 	end
 	
 	function exported.listen(callback)
-		table.insert(listeners, callback)
-		
+		local listener = {
+			Callback = callback,
+			OnceCallback = false	
+		}
+		table.insert(listeners, listener)
+
 		return function()
-			exported.disconnect(callback)
+			exported.disconnect(listener)
 		end
 	end
 	
@@ -58,14 +60,26 @@ return function(properties: types.queryProperties<types.dataTypeInterface<any>, 
 		table.clear(listeners)
 	end
 	
-	function exported.disconnect(callback)
-		table.remove(listeners, table.find(listeners, callback))
+	function exported.disconnect(listener)
+		-- Ensure the index isn't nil to avoid removing arbitrary listeners
+		local index = table.find(listeners, listener)
+		if index ~= nil then
+			table.remove(listeners, index)
+		else
+			warn('Query listener was already disconnected.')
+		end
 	end
 	
 	function exported.listenOnce(callback)
-		table.insert(listeners, {
-			["OnceCallback"] = callback	
-		})
+		local listener = {
+			Callback = callback,
+			OnceCallback = true	
+		}
+		table.insert(listeners, listener)
+
+		return function()
+			exported.disconnect(listener)
+		end
 	end
 	
 	function exported.getListeners()

--- a/src/types.luau
+++ b/src/types.luau
@@ -53,6 +53,16 @@ export type dataTypeInterface<T> = {
 	read: (b: buffer, cursor: number, references: { [number]: unknown }?) -> (T, number),
 }
 
+-- Used internally to store callbacks and their state for both packets and queries
+export type Listener<T> = {
+	Callback: (data: T, target: Player?) -> any,
+	OnceCallback: boolean
+}
+export type QueryListener<RequestType, ResponseType> = Listener<RequestType> & {
+	Callback: (data: RequestType, target: Player?) -> ResponseType,
+	Disconnecting: boolean?
+}
+
 -- Somewhat public facing: used as return result in definePacket
 type Packet<T> = {
 	sendToAll: (data: T) -> (),


### PR DESCRIPTION
This unifies listeners to always be a table, and ensures issues caused by them being removed mid-iteration don't occur (it also never removed the correct listener in the first place, so that's fixed as well !)

There might still be issues should a game call disconnect() on a query listener while it is being invoked, but I don't see much of a reason to _do_ that in the first place.