### PR TITLE
Fix cframe deserialization

### DIFF
--- a/src/dataTypes/cframe.luau
+++ b/src/dataTypes/cframe.luau
@@ -6,23 +6,29 @@ local alloc = bufferWriter.alloc
 
 local cframe = {
 	read = function(b: buffer, cursor: number)
-		local x : number = buffer.readf32(b, cursor)
-		local y : number = buffer.readf32(b, cursor + 4)
-		local z : number = buffer.readf32(b, cursor + 8)
-		local rx : number = buffer.readf32(b, cursor + 12)
-		local ry : number = buffer.readf32(b, cursor + 16)
-		local rz : number = buffer.readf32(b, cursor + 20)
+		local x: number = buffer.readf32(b, cursor)
+		local y: number = buffer.readf32(b, cursor + 4)
+		local z: number = buffer.readf32(b, cursor + 8)
+		local rx: number = buffer.readf32(b, cursor + 12)
+		local ry: number = buffer.readf32(b, cursor + 16)
+		local rz: number = buffer.readf32(b, cursor + 20)
 
-		return CFrame.Angles(rx, ry, rz) + Vector3.new(x, y, z), 24
+		local axis: Vector3 = Vector3.new(rx, ry, rz)
+		local angle: number = axis.Magnitude
+
+		if angle ~= 0 then
+			-- fromAxisAngle will normalize the axis so we don't need to do it here
+			return CFrame.new(x, y, z) * CFrame.fromAxisAngle(axis, angle), 24
+		else
+			return CFrame.new(x, y, z), 24
+		end
 	end,
 	write = function(value: CFrame)
-		local x : number, y : number, z : number = value.X, value.Y, value.Z
-		local axis : Vector3, angle : number = value:ToAxisAngle()
+		local x: number, y: number, z: number = value.X, value.Y, value.Z
+		local axis: Vector3, angle: number = value:ToAxisAngle()
 		axis *= angle
+		local rx: number, ry: number, rz: number = axis.X, axis.Y, axis.Z
 
-		local rx : number, ry : number, rz : number = axis.X, axis.Y, axis.Z
-
-		-- Math done, write it now
 		alloc(24)
 		f32NoAlloc(x)
 		f32NoAlloc(y)


### PR DESCRIPTION
Replaced the CFrame.Angles call in deserialization with CFrame.fromAxisAngles, matching the CFrame.ToAxisAngles call in the serialization function. Previously, the mismatch between methods caused incorrect ser/de results.