### PR TITLE
[codex] build clear ByteNet Max documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - requirements-docs.txt
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install documentation dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,217 +1,68 @@
-<div align="center"><h1><b>ByteNet Max</b></h1></div>
-<div align="center"><h2><b>An upgraded buffer-based networking system</b></h2></div>
-<div align="center"><a href="https://github.com/Elitriare/ByteNet-Max">GitHub</a> | <a href="https://wally.run/package/elitriare/bytenet-max?version=0.2.1">Wally</a> | <a href="https://create.roblox.com/store/asset/81428213632345/ByteNet-Max">Roblox Creator Store</a></div>
+<div align="center">
 
-ByteNet Max is an upgraded version of @ffrostfall's [ByteNet](https://devforum.roblox.com/t/bytenet-advanced-networking-library-w-buffer-serialization-strict-luau-absurd-optimization-and-rbxts-support-043/2733365) which relies on strict type-checking to serialise your data into buffers before deserialising it on the other end, feeding it back to your Luau code. But what makes ByteNet Max different from ByteNet? ByteNet Max supports queries (RemoteFunctions) which are client to server requests for data. This brings you an extremely optimised experience for RemoteFunctions, using minimal data to increase send and receive speeds. ByteNet Max lives up to ByteNet's idea of making networking simple, easy and quick. The API is simple and minimalistic, helping you grasp the concepts of ByteNet Max pretty quickly!
+# ByteNet Max
 
-<h3><b>Installation</b></h3> 
+Typed, buffer-based networking for Roblox—with packets for events and queries for request/response calls.
 
-Get [ByteNet Max](https://create.roblox.com/store/asset/81428213632345/ByteNet-Max) on the Roblox Creator Store, or on [Wally](https://wally.run/package/elitriare/bytenet-max?version=0.2.1) **(WARNING: v1.0.0 is the FIRST version of ByteNet Max, due to an error I made. The latest version is always the one shown on the title of this post)**!
+[Documentation](https://elitriare.github.io/ByteNet-Max/) · [Wally](https://wally.run/package/elitriare/bytenet-max) · [Creator Store](https://create.roblox.com/store/asset/81428213632345/ByteNet-Max)
 
-<h3><b>Performance</b></h3> 
+</div>
 
-ByteNet Max lives up to the standards of ByteNet, performing incredibly well compared to other networking libraries such as BridgeNet2. The conversion to a buffer reduces memory usage significantly, helping optimise and speed up data transfer.
+## What it provides
 
-<h3><b>Documentation</b></h3> 
+- Typed buffer serialization for compact network payloads
+- Reliable and unreliable packets
+- Client-to-server queries with typed responses
+- Frame-batched packet traffic
+- Composable schemas for Roblox and Luau values
 
-ByteNet Max follows the same architecture as ByteNet, hence the documentation for RemoteEvents (packets) is the exact same and can be found here: [Documentation](https://ffrostfall.github.io/ByteNet/api/functions/definePacket/).
+## Install with Wally
 
- **Due to ByteNet documentation being outdated, here is a simple setup guide for a remote event.**
+```toml
+[dependencies]
+ByteNetMax = "elitriare/bytenet-max@0.2.7"
+```
 
+Check the [Wally package](https://wally.run/package/elitriare/bytenet-max) for the latest published version.
 
-**Packets ModuleScript:**
-Create a ModuleScript that will hold your namespaces.
+## Minimal example
+
+Define networking once in a shared ModuleScript:
+
 ```lua
-local ByteNetMax = require(path.to.ByteNetMax)
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ByteNetMax = require(ReplicatedStorage.Packages.ByteNetMax)
 
-return ByteNetMax.defineNamespace("Main", function()
+return ByteNetMax.defineNamespace("Game", function()
 	return {
 		packets = {
-
-			Test = ByteNetMax.definePacket({
-				value = ByteNetMax.struct({
-					Action = ByteNetMax.string,
-					Data = ByteNetMax.string
-				}),
-			})
-		}
-	}
-
-end)
-```
-
-**Server listener:**
-Create a simple script to listen to this event, and prints out what the client sent.
-```lua
-
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-
-local BytePackets = require(path.to.Packets_ModuleScript)
-
-
-BytePackets.packets.Test.listen(function(data, plr)
-	
-	-- prints the action
-	print(data.Action)
-	
-	-- prints some other data
-	print(data.Data)
-	
-	
-end)
-```
-
-**Localscript that sends information:**
-This is just a simple script that sends over your input to the server.
-```lua
-local UserInputService = game:GetService("UserInputService")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-
-local BytePackets = require(path.to.Packets_ModuleScript)
-
-UserInputService.InputBegan:Connect(function(Input, gameProcessed)
-	
-	if gameProcessed or Input.KeyCode.Name == "Unknown" then return end
-	
-	
-	BytePackets.packets.Test.send({
-		Action = Input.KeyCode.Name,
-		Data = 'Whatever data you want to go along with the action here'
-	})
-	
-end)
-```
-
-<h3><b>Max-specific Documentation</b></h3> 
-
-
-However, it adds a new system named **queries**. This is the ByteNet equivalent of a RemoteFunction. To begin, you can create a ModuleScript to define a namespace under which your packets and queries will be held:
-```lua
-local ByteNetMax = require(path.to.ByteNetMax)
-
-return ByteNetMax.defineNamespace("PlayerData", function()
-    return {
-       packets = {}, -- not necessary to include this table if there's no values in it.
-       queries = {
+			Announcement = ByteNetMax.definePacket({
+				value = ByteNetMax.string,
+			}),
+		},
+		queries = {
 			GetCoins = ByteNetMax.defineQuery({
-				request = ByteNetMax.struct({
-					message = ByteNetMax.string
-				}),
-				response = ByteNetMax.struct({
-					coins = ByteNetMax.uint8
-				})
-			})
-		},		
-    }
-end)
-```
-
-Then, in a local script, you can invoke the query like so:
-```lua
-local QueryModule = require(path.to.QueryModule)
-
-local Coins = QueryModule.queries.GetCoins.invoke({
-	message = "Can I please get the coins value?"
-})
-
-print(Coins)
-```
-
-In a server script, you can receive the query and return the appropriate information, like so:
-```lua
-local QueryModule = require(path.to.QueryModule)
-
-QueryModule.queries.GetCoins.listen(function(data, player)	
-    print(data.message) -- prints "Can I please get the coins value?"
-	return {coins = player.leaderstats.Coins.Value}
-end)
-```
-
-If you want to disconnect the listener in the future, you can assign the function to a variable:
-```lua
-local QueryModule = require(path.to.QueryModule)
-local Listener 
-
-Listener = QueryModule.queries.GetCoins.listen(function(data, player)	
-    print(data.message) -- prints "Can I please get the coins value?"
-	return {coins = player.leaderstats.Coins.Value}
-end)
-
-Listener() -- disconnects listener
-```
-
-The above function works with **packets** too!
-
-It's that simple!
-
-<h3><b>Auto dataType (easy mode)</b></h3>
-
-`ByteNetMax.auto` is a flexible dataType for when you just want to send something quickly without deciding the exact type first.
-
-It writes a 1-byte type marker, then automatically picks a compact serializer for the value you pass.
-
-That means numbers use the smallest fitting numeric format (for example uint8/int8/int16/etc) when possible.
-
-**Good for:** quick prototypes, mixed payloads, and newer developers getting started.
-
-**Best practice:** if your payload shape is fixed, `struct(...)` with explicit field types is still ideal.
-
-Example packet using `auto`:
-```lua
-local ByteNetMax = require(path.to.ByteNetMax)
-
-return ByteNetMax.defineNamespace("AutoDemo", function()
-	return {
-		packets = {
-			DebugValue = ByteNetMax.definePacket({
-				value = ByteNetMax.auto,
+				request = ByteNetMax.nothing,
+				response = ByteNetMax.uint32,
 			}),
 		},
 	}
 end)
 ```
 
-Example sends:
-```lua
-local AutoDemo = require(path.to.AutoDemo)
+Require that shared module on both the server and client. See the [getting started guide](https://elitriare.github.io/ByteNet-Max/getting-started/installation/) for the complete setup.
 
-AutoDemo.packets.DebugValue.send(123)
-AutoDemo.packets.DebugValue.send("hello")
-AutoDemo.packets.DebugValue.send(true)
-AutoDemo.packets.DebugValue.send(Vector3.new(1, 2, 3))
-AutoDemo.packets.DebugValue.send(nil)
-```
+## Documentation
 
-`auto` currently supports: `nil`, `boolean`, `number`, `string`, `Vector2`, `Vector3`, `Color3`, `CFrame` (and falls back to unknown/reference behavior for values like `Instance`, `buffer`, and custom userdata).
+The dedicated documentation covers:
 
-Packets & Queries can co-exist under the same namespace, just make sure you define the packets and queries table in defineNamespace. If you don't require packets, you can leave it out and just define the queries table, and vice versa.
+- [Your first packet](https://elitriare.github.io/ByteNet-Max/getting-started/first-packet/)
+- [Your first query](https://elitriare.github.io/ByteNet-Max/getting-started/first-query/)
+- [Packet API](https://elitriare.github.io/ByteNet-Max/api/packet/)
+- [Query API](https://elitriare.github.io/ByteNet-Max/api/query/)
+- [Data types](https://elitriare.github.io/ByteNet-Max/api/data-types/)
+- [Security and limits](https://elitriare.github.io/ByteNet-Max/guides/security/)
 
-<b>IMPORTANT:</b> <u><b><i>You must require the ModuleScript you created on both the server and client! This is to initialise server side & client side dependencies for a secure network.</b></i></u>
+## License
 
-<h2>Some extra functions</h2>
-
-ByteNet Max also adds extra functions for both packets & queries for better control over your code. You can now use .listenOnce() and .disconnectAll() to call a function once or disable all callbacks connected to a packet/query (equivalent to the :Disconnect() and :Once() functions from Roblox)
-
-Using the example above, .listenOnce() is used the same way as .listen() : 
-```lua
-local QueryModule = require(path.to.QueryModule)
-
-QueryModule.queries.GetCoins.listenOnce(function(data, player)	 -- this callback only runs once, before disconnecting.
-    print(data.message) -- prints "Can I please get the coins value?"
-	return {coins = player.leaderstats.Coins.Value}
-end)
-```
-
-The .disconnectAll() function can be used to completely erase every callback created through .listen():
-```lua
-local QueryModule = require(path.to.QueryModule)
-
-QueryModule.queries.GetCoins.disconnectAll() -- disconnects all callbacks
-```
-
-
-<h3><b>Contact</b></h3> 
-
-Contact me on [Twitter](https://x.com/Elitriare) or Discord (username: elitriare), or just on this thread to report bugs or request features. I haven't fully tested this across different types of experiences, so your ***feedback*** is extremely useful!
-
-This project is open-source.
+ByteNet Max is available under the [MIT License](LICENSE).

--- a/docs/api/data-types.md
+++ b/docs/api/data-types.md
@@ -1,0 +1,89 @@
+# Data types
+
+Data types describe how ByteNet Max serializes values. Primitive exports are values; constructors such as `struct`, `array`, `map`, and `optional` are functions.
+
+## Numbers
+
+| Type | Value | Encoded size | Range / precision |
+| --- | --- | ---: | --- |
+| `uint8` | Integer | 1 byte | 0 to 255 |
+| `uint16` | Integer | 2 bytes | 0 to 65,535 |
+| `uint32` | Integer | 4 bytes | 0 to 4,294,967,295 |
+| `int8` | Integer | 1 byte | −128 to 127 |
+| `int16` | Integer | 2 bytes | −32,768 to 32,767 |
+| `int32` | Integer | 4 bytes | −2,147,483,648 to 2,147,483,647 |
+| `float32` | Number | 4 bytes | 32-bit floating point |
+| `float64` | Number | 8 bytes | 64-bit floating point |
+
+```lua
+Score = ByteNetMax.uint32
+Temperature = ByteNetMax.float32
+```
+
+## Roblox and primitive values
+
+| Type | Luau value | Encoded size | Notes |
+| --- | --- | ---: | --- |
+| `bool` | `boolean` | 1 byte | `0` or `1` |
+| `string` | `string` | 2-byte length + data | Length prefix is `uint16` |
+| `vec2` | `Vector2` | 8 bytes | Two float32 components |
+| `vec3` | `Vector3` | 12 bytes | Three float32 components |
+| `color3` | `Color3` | 3 bytes | RGB channels quantized to 8 bits |
+| `cframe` | `CFrame` | 24 bytes | Position and axis-angle rotation as float32s |
+| `buff` | `buffer` | 4-byte length + data | Copies the buffer payload |
+| `inst` | `Instance?` | 2-byte reference index | Uses the transport's reference list |
+| `unknown` | `unknown` | 2-byte reference index | Uses the transport's reference list |
+| `nothing` | `nil` | 0 bytes | Useful for empty query requests |
+
+## `struct(fields)`
+
+Serializes a fixed dictionary shape.
+
+```lua
+local PlayerState = ByteNetMax.struct({
+	Health = ByteNetMax.uint16,
+	Position = ByteNetMax.vec3,
+	Name = ByteNetMax.string,
+})
+```
+
+The encoded size is the sum of its field sizes.
+
+## `array(valueType)`
+
+Serializes a sequential array. Its count uses a 2-byte `uint16` prefix.
+
+```lua
+local Tags = ByteNetMax.array(ByteNetMax.string)
+```
+
+## `map(keyType, valueType)`
+
+Serializes a dictionary as key/value pairs. Its count uses a 2-byte `uint16` prefix.
+
+```lua
+local Scores = ByteNetMax.map(ByteNetMax.string, ByteNetMax.uint32)
+```
+
+## `optional(valueType)`
+
+Serializes a 1-byte presence marker, followed by the value when it is not `nil`.
+
+```lua
+local Subtitle = ByteNetMax.optional(ByteNetMax.string)
+```
+
+## `auto`
+
+Detects the value's type at runtime and adds a 1-byte type marker. Integers use the smallest fitting numeric codec; exact float32 values use `float32`, otherwise `float64` is used.
+
+Supported direct codecs are `nil`, boolean, number, string, `Vector2`, `Vector3`, `Color3`, and `CFrame`. Other values use the reference-based `unknown` codec.
+
+## Aliases
+
+| Alias | Equivalent type |
+| --- | --- |
+| `playerName` | `string` |
+| `playerIdentifier` | `uint8` |
+
+These are compatibility aliases in the current public module. For Roblox `UserId` values, prefer a type with sufficient range such as `uint32`.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,39 @@
+# API overview
+
+The public module exports three definition functions and a set of composable data types.
+
+| Export | Purpose |
+| --- | --- |
+| [`defineNamespace`](namespace.md) | Group and initialize packets and queries |
+| [`definePacket`](packet.md) | Define a one-way typed message |
+| [`defineQuery`](query.md) | Define a typed request and response |
+| [Data types](data-types.md) | Describe serialized values |
+
+## Typical definition
+
+```lua
+return ByteNetMax.defineNamespace("Game", function()
+	return {
+		packets = {
+			StatusChanged = ByteNetMax.definePacket({
+				value = ByteNetMax.string,
+			}),
+		},
+		queries = {
+			GetStatus = ByteNetMax.defineQuery({
+				request = ByteNetMax.nothing,
+				response = ByteNetMax.string,
+			}),
+		},
+	}
+end)
+```
+
+All functions use dot syntax:
+
+```lua
+Packet.send(Data)
+Packet.listen(Callback)
+```
+
+Do not use colon syntax (`Packet:send(Data)`).

--- a/docs/api/namespace.md
+++ b/docs/api/namespace.md
@@ -1,0 +1,43 @@
+# `defineNamespace`
+
+Groups packet and query definitions and coordinates their IDs between the server and clients.
+
+```lua
+ByteNetMax.defineNamespace(Name, DefinitionCallback)
+```
+
+## Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `Name` | `string` | Stable, unique namespace name |
+| `DefinitionCallback` | `() -> table` | Returns optional `packets` and `queries` tables |
+
+## Returns
+
+```lua
+{
+	packets = { [string]: Packet },
+	queries = { [string]: Query },
+}
+```
+
+## Example
+
+```lua
+local Network = ByteNetMax.defineNamespace("Chat", function()
+	return {
+		packets = {
+			SendMessage = ByteNetMax.definePacket({
+				value = ByteNetMax.string,
+			}),
+		},
+		queries = {},
+	}
+end)
+```
+
+The empty tables are optional. A packet-only namespace may omit `queries`, and a query-only namespace may omit `packets`.
+
+!!! important
+    Define a namespace in one shared ModuleScript and require that module on both server and client. Do not maintain two hand-written copies of the schema.

--- a/docs/api/packet.md
+++ b/docs/api/packet.md
@@ -1,0 +1,35 @@
+# `definePacket`
+
+Defines a typed, one-way message.
+
+```lua
+ByteNetMax.definePacket({
+	value = DataType,
+	reliabilityType = "reliable", -- optional
+})
+```
+
+## Properties
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `value` | Yes | Data type used to serialize the packet payload |
+| `reliabilityType` | No | `"reliable"` (default) or `"unreliable"` |
+
+## Methods
+
+| Method | Runtime | Returns | Description |
+| --- | --- | --- | --- |
+| `send(data)` | Client | `nil` | Queues data for the server |
+| `sendTo(data, player)` | Server | `nil` | Queues data for one client |
+| `sendToList(data, players)` | Server | `nil` | Queues data for each listed client |
+| `sendToAll(data)` | Server | `nil` | Queues data for all clients |
+| `sendToAllExcept(data, player)` | Server | `nil` | Queues data for all clients except one |
+| `listen(callback)` | Both | Disconnect function | Adds a persistent listener |
+| `listenOnce(callback)` | Both | Disconnect function | Adds a one-use listener |
+| `wait()` | Both | Received values | Yields until the next packet |
+| `disconnectAll()` | Both | `nil` | Removes all listeners for this packet |
+
+On the server, listeners receive `(Data, Player)`. On the client, listeners receive `(Data)`.
+
+See the [Packets guide](../guides/packets.md) for complete examples.

--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -1,0 +1,31 @@
+# `defineQuery`
+
+Defines a typed client-to-server request and server-to-client response.
+
+```lua
+ByteNetMax.defineQuery({
+	request = RequestDataType,
+	response = ResponseDataType,
+})
+```
+
+## Properties
+
+| Property | Required | Description |
+| --- | --- | --- |
+| `request` | Yes | Data type used to serialize the client request |
+| `response` | Yes | Data type used to serialize the server response |
+
+## Methods
+
+| Method | Runtime | Returns | Description |
+| --- | --- | --- | --- |
+| `invoke(request)` | Client | Response value | Yields until the server responds |
+| `listen(callback)` | Server | Disconnect function | Adds a persistent request handler |
+| `listenOnce(callback)` | Server | Disconnect function | Handles one request, then disconnects |
+| `wait()` | Server | Request and player | Yields until a request arrives |
+| `disconnectAll()` | Both | `nil` | Removes all listeners for this query |
+
+The server callback receives `(Request, Player)` and must return a value compatible with `response`.
+
+See the [Queries guide](../guides/queries.md) for lifecycle and safety guidance.

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -1,0 +1,63 @@
+:root {
+  --md-primary-fg-color: #6d5dfc;
+  --md-primary-fg-color--light: #8b7fff;
+  --md-primary-fg-color--dark: #5143d9;
+  --md-accent-fg-color: #8b7fff;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: #0d1020;
+  --md-default-bg-color--light: #14182b;
+  --md-code-bg-color: #14182b;
+  --md-typeset-a-color: #a59cff;
+}
+
+.md-header {
+  background: linear-gradient(90deg, #5143d9, #6d5dfc);
+}
+
+.md-typeset h1 {
+  font-weight: 750;
+  letter-spacing: -0.03em;
+}
+
+.md-typeset h2 {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.md-typeset code {
+  border-radius: 0.3rem;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin: 2rem 0;
+}
+
+.feature-card {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.75rem;
+  padding: 0.4rem 1rem 0.8rem;
+  background: var(--md-default-bg-color--light);
+}
+
+.feature-card h2 {
+  margin-top: 0.65rem;
+}
+
+.md-typeset .md-button {
+  border-radius: 0.45rem;
+}
+
+.md-typeset table:not([class]) th {
+  font-weight: 700;
+}
+
+@media screen and (max-width: 44.9844em) {
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -1,0 +1,61 @@
+# Core concepts
+
+## Namespace
+
+A namespace groups related packets and queries. ByteNet Max assigns their numeric IDs on the server and shares the mapping with clients.
+
+```lua
+ByteNetMax.defineNamespace("Inventory", function()
+	return {
+		packets = { ... },
+		queries = { ... },
+	}
+end)
+```
+
+Use one shared ModuleScript for each namespace. Give every namespace a stable, unique name.
+
+## Packet
+
+A packet sends data in one direction and does not produce a return value. Packets support:
+
+- Client → server with `send`
+- Server → one client with `sendTo`
+- Server → a list with `sendToList`
+- Server → everyone with `sendToAll`
+- Server → everyone except one client with `sendToAllExcept`
+
+## Query
+
+A query sends a typed request from the client to the server and returns a typed response. It is ByteNet Max's request/response primitive.
+
+## Data type
+
+A ByteNet Max data type knows how to encode and decode a value. Schemas compose these types:
+
+```lua
+ByteNetMax.struct({
+	Name = ByteNetMax.string,
+	Level = ByteNetMax.uint16,
+	Position = ByteNetMax.vec3,
+	Nickname = ByteNetMax.optional(ByteNetMax.string),
+})
+```
+
+Explicit types are usually smaller and clearer than `auto`.
+
+## Shared initialization
+
+The namespace definition must run on both the server and client. Sharing a single ModuleScript prevents the two sides from drifting apart.
+
+```mermaid
+flowchart LR
+    D["Shared namespace module"] --> S["Server requires module"]
+    D --> C["Client requires module"]
+    S --> M["Server publishes ID and struct metadata"]
+    M --> C
+```
+
+## Server authority
+
+Serialization checks the shape of network data; it does not make client input trustworthy. The server must still decide whether the requested action is valid.

--- a/docs/getting-started/first-packet.md
+++ b/docs/getting-started/first-packet.md
@@ -1,0 +1,58 @@
+# Your first packet
+
+A packet is a one-way message. In this example, the client tells the server which action it requested.
+
+## 1. Define it once
+
+Create a shared ModuleScript:
+
+```lua title="ReplicatedStorage/Network.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ByteNetMax = require(ReplicatedStorage.ByteNetMax)
+
+return ByteNetMax.defineNamespace("Tutorial", function()
+	return {
+		packets = {
+			RequestAction = ByteNetMax.definePacket({
+				value = ByteNetMax.struct({
+					Action = ByteNetMax.string,
+				}),
+			}),
+		},
+	}
+end)
+```
+
+`value` is the packet's schema. Sending anything that does not match this shape can fail during serialization.
+
+## 2. Listen on the server
+
+```lua title="ServerScriptService/Network.server.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Network = require(ReplicatedStorage.Network)
+
+Network.packets.RequestAction.listen(function(Data, Player)
+	print(`{Player.Name} requested {Data.Action}`)
+end)
+```
+
+On the server, packet callbacks receive `(Data, Player)`.
+
+## 3. Send from the client
+
+```lua title="StarterPlayerScripts/Network.client.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Network = require(ReplicatedStorage.Network)
+
+Network.packets.RequestAction.send({
+	Action = "Dash",
+})
+```
+
+The client uses `send`. The server uses methods such as `sendTo` and `sendToAll`.
+
+!!! warning "Packets are not security boundaries"
+    A client can request any action at any time. Validate permissions, cooldowns, distance, ownership, and all other authoritative state on the server.
+
+[See every packet method](../guides/packets.md){ .md-button }
+[Create a query](first-query.md){ .md-button }

--- a/docs/getting-started/first-query.md
+++ b/docs/getting-started/first-query.md
@@ -1,0 +1,58 @@
+# Your first query
+
+A query is a client-to-server request that returns a response. Use it when the caller cannot continue without a server result.
+
+## 1. Define request and response types
+
+```lua title="ReplicatedStorage/Network.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ByteNetMax = require(ReplicatedStorage.ByteNetMax)
+
+return ByteNetMax.defineNamespace("PlayerData", function()
+	return {
+		queries = {
+			GetItemCount = ByteNetMax.defineQuery({
+				request = ByteNetMax.struct({
+					ItemId = ByteNetMax.string,
+				}),
+				response = ByteNetMax.uint16,
+			}),
+		},
+	}
+end)
+```
+
+## 2. Return the response on the server
+
+```lua title="ServerScriptService/Network.server.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Network = require(ReplicatedStorage.Network)
+
+Network.queries.GetItemCount.listen(function(Request, Player)
+	-- Replace this with a lookup in server-owned player data.
+	local Inventory = GetInventoryFor(Player)
+	return Inventory[Request.ItemId] or 0
+end)
+```
+
+The returned value must match the query's `response` data type.
+
+## 3. Invoke it on the client
+
+```lua title="StarterPlayerScripts/Network.client.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Network = require(ReplicatedStorage.Network)
+
+local PotionCount = Network.queries.GetItemCount.invoke({
+	ItemId = "HealthPotion",
+})
+
+print(`Potions: {PotionCount}`)
+```
+
+`invoke` yields until the server responds. Do not invoke a query every frame or use one for fire-and-forget notifications.
+
+!!! tip "No request data?"
+    Use `request = ByteNetMax.nothing`, then call `invoke(nil)`.
+
+[Understand query behavior](../guides/queries.md){ .md-button .md-button--primary }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,58 @@
+# Installation
+
+Install ByteNet Max from Wally or the Roblox Creator Store. Wally is the recommended option for projects already managed with Rojo.
+
+## Wally
+
+Add ByteNet Max to `wally.toml`:
+
+```toml
+[dependencies]
+ByteNetMax = "elitriare/bytenet-max@0.2.7"
+```
+
+Install the package:
+
+```shell
+wally install
+```
+
+Then require the installed ModuleScript. The exact path depends on your Rojo project:
+
+```lua
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ByteNetMax = require(ReplicatedStorage.Packages.ByteNetMax)
+```
+
+Check the [Wally package](https://wally.run/package/elitriare/bytenet-max) for the latest published version before pinning it.
+
+## Roblox Creator Store
+
+Get [ByteNet Max from the Creator Store](https://create.roblox.com/store/asset/81428213632345/ByteNet-Max), insert it into your experience, and move the module to a shared location such as `ReplicatedStorage`.
+
+```text
+ReplicatedStorage
+├── ByteNetMax
+└── Network
+```
+
+## Project layout
+
+A small project normally needs three scripts:
+
+```text
+ReplicatedStorage
+├── ByteNetMax
+└── Network.luau             # Shared definitions
+ServerScriptService
+└── Network.server.luau      # Server listeners and sends
+StarterPlayer
+└── StarterPlayerScripts
+    └── Network.client.luau  # Client listeners and sends
+```
+
+Both runtime sides must require `Network.luau`. The server should initialize its networking code during startup so namespace metadata exists before the client reads it.
+
+## Next step
+
+[Create your first packet](first-packet.md){ .md-button .md-button--primary }

--- a/docs/guides/choosing-data-types.md
+++ b/docs/guides/choosing-data-types.md
@@ -1,0 +1,67 @@
+# Choosing data types
+
+Choose the narrowest type that covers the values you expect. Smaller types reduce bandwidth and make the schema explain itself.
+
+## A practical schema
+
+```lua
+ByteNetMax.struct({
+	UserId = ByteNetMax.uint32,
+	DisplayName = ByteNetMax.string,
+	Position = ByteNetMax.vec3,
+	Health = ByteNetMax.uint16,
+	IsAlive = ByteNetMax.bool,
+	Title = ByteNetMax.optional(ByteNetMax.string),
+})
+```
+
+## Numbers
+
+- Use `uint8` for integers from 0 to 255.
+- Use `uint16` for integers from 0 to 65,535.
+- Use `uint32` for larger non-negative integers.
+- Use signed integers when negatives are valid.
+- Use `float32` for most decimal gameplay values.
+- Use `float64` only when you need its additional precision.
+
+## Collections
+
+Use `array(type)` for sequential lists and `map(keyType, valueType)` for dictionaries.
+
+```lua
+Inventory = ByteNetMax.array(ByteNetMax.struct({
+	ItemId = ByteNetMax.string,
+	Amount = ByteNetMax.uint16,
+}))
+
+Cooldowns = ByteNetMax.map(ByteNetMax.string, ByteNetMax.float32)
+```
+
+Arrays and maps store their count as a `uint16`, so one value can contain at most 65,535 entries.
+
+## Optional values
+
+`optional(type)` adds a one-byte presence marker:
+
+```lua
+Target = ByteNetMax.optional(ByteNetMax.inst)
+```
+
+## `auto`
+
+`auto` writes a one-byte type marker and selects a codec at runtime. It supports `nil`, booleans, numbers, strings, `Vector2`, `Vector3`, `Color3`, and `CFrame`; other values fall back to the reference-based `unknown` codec.
+
+```lua
+DebugValue = ByteNetMax.definePacket({
+	value = ByteNetMax.auto,
+})
+```
+
+Use `auto` for prototypes, debugging, or intentionally mixed values. Prefer explicit schemas for production traffic because they are easier to review and avoid a per-value type tag.
+
+## Instances and unknown values
+
+`inst` and `unknown` use a reference list alongside the serialized buffer. Use `inst` when the value should be an `Instance`; use `unknown` only when a stable explicit schema is not possible.
+
+!!! tip
+    If a payload has a known shape, a `struct` of explicit types is normally the best choice.

--- a/docs/guides/packets.md
+++ b/docs/guides/packets.md
@@ -1,0 +1,123 @@
+# Packets
+
+Packets are typed, one-way messages. Choose them when the sender does not need a direct return value.
+
+## Define a packet
+
+```lua
+UpdateHealth = ByteNetMax.definePacket({
+	value = ByteNetMax.struct({
+		Current = ByteNetMax.uint16,
+		Maximum = ByteNetMax.uint16,
+	}),
+})
+```
+
+The `value` field is required. `reliabilityType` is optional and defaults to `"reliable"`.
+
+## Client methods
+
+### `send(data)`
+
+Queues data for the server.
+
+```lua
+Network.packets.RequestAbility.send({ AbilityId = "Dash" })
+```
+
+The server receives the sending `Player` as the callback's second argument.
+
+## Server methods
+
+### `sendTo(data, player)`
+
+Sends to one player. Data is the first argument.
+
+```lua
+Network.packets.UpdateHealth.sendTo({
+	Current = 75,
+	Maximum = 100,
+}, Player)
+```
+
+### `sendToList(data, players)`
+
+Sends the same data to each player in an array.
+
+```lua
+Network.packets.RoundState.sendToList({ State = "Active" }, TeamPlayers)
+```
+
+### `sendToAll(data)`
+
+Broadcasts to every connected player.
+
+```lua
+Network.packets.Announcement.sendToAll({ Text = "Round starting" })
+```
+
+### `sendToAllExcept(data, player)`
+
+Broadcasts to everyone except one player.
+
+```lua
+Network.packets.PlayerMoved.sendToAllExcept(MovementData, MovingPlayer)
+```
+
+## Listening
+
+These methods exist on both sides.
+
+### `listen(callback)`
+
+Registers a persistent callback and returns a disconnect function.
+
+```lua
+local Disconnect = Network.packets.Announcement.listen(function(Data)
+	print(Data.Text)
+end)
+
+Disconnect()
+```
+
+The callback receives `(Data, Player)` on the server and `(Data)` on the client.
+
+### `listenOnce(callback)`
+
+Runs the callback for the next received packet, then removes it. It also returns a disconnect function.
+
+```lua
+Network.packets.Ready.listenOnce(function(Data, Player)
+	print(Player, Data)
+end)
+```
+
+### `wait()`
+
+Yields the current thread until the next packet arrives and returns the same values a callback receives.
+
+```lua
+local Data, Player = Network.packets.Ready.wait()
+```
+
+### `disconnectAll()`
+
+Removes every listener attached to that packet in the current runtime.
+
+```lua
+Network.packets.Ready.disconnectAll()
+```
+
+!!! warning
+    `disconnectAll()` affects listeners created by other scripts too. Prefer the disconnect function returned by `listen` when you own only one listener.
+
+## Reliable and unreliable packets
+
+```lua
+AimDirection = ByteNetMax.definePacket({
+	value = ByteNetMax.vec3,
+	reliabilityType = "unreliable",
+})
+```
+
+Use `"reliable"` for state changes that must arrive. Use `"unreliable"` for frequent updates where a newer value replaces an older one. See [Reliability and batching](reliability.md).

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -1,0 +1,67 @@
+# Queries
+
+Queries provide typed client-to-server request/response calls.
+
+## Define a query
+
+Every query requires both a request and response data type:
+
+```lua
+GetLoadout = ByteNetMax.defineQuery({
+	request = ByteNetMax.nothing,
+	response = ByteNetMax.array(ByteNetMax.string),
+})
+```
+
+## Handle it on the server
+
+Register one server listener and return a response of the declared type:
+
+```lua
+Network.queries.GetLoadout.listen(function(_, Player)
+	return LoadoutService:GetItemIds(Player)
+end)
+```
+
+The callback receives `(Request, Player)`.
+
+## Invoke it on the client
+
+```lua
+local ItemIds = Network.queries.GetLoadout.invoke(nil)
+```
+
+`invoke` yields the calling thread until it receives the response.
+
+## Listener lifecycle
+
+Queries expose the same listener utilities as packets:
+
+| Method | Behavior |
+| --- | --- |
+| `listen(callback)` | Registers a handler and returns a disconnect function |
+| `listenOnce(callback)` | Handles the next request, then disconnects |
+| `wait()` | Yields for the next request |
+| `disconnectAll()` | Removes all query listeners in this runtime |
+
+## Rules for robust queries
+
+1. Register exactly one active server handler for each query.
+2. Always return a value compatible with `response`.
+3. Return promptly. The current server implementation stops waiting after 10 seconds.
+4. Validate the request using server-owned state.
+5. Do not use queries for high-frequency updates or notifications.
+
+!!! danger "Do not trust query arguments"
+    A query is still client input. Treat `Player` as the identity and verify every requested resource, item, amount, and permission on the server.
+
+## When a packet is better
+
+Use a packet when the client does not need an immediate result. A packet avoids blocking the caller and communicates intent more clearly.
+
+| Scenario | Recommended primitive |
+| --- | --- |
+| Fetch a profile summary | Query |
+| Request a purchase and need a result | Query |
+| Tell the server a button was pressed | Packet |
+| Push a UI update to a client | Packet |

--- a/docs/guides/reliability.md
+++ b/docs/guides/reliability.md
@@ -1,0 +1,51 @@
+# Reliability and batching
+
+## Reliable packets
+
+Reliable packets use a Roblox `RemoteEvent` and are the default.
+
+```lua
+InventoryChanged = ByteNetMax.definePacket({
+	value = InventoryChangeType,
+	reliabilityType = "reliable",
+})
+```
+
+Use reliable delivery for messages where losing one update would make state incorrect:
+
+- Inventory and economy changes
+- Round transitions
+- Confirmed actions
+- UI state that is not continuously refreshed
+
+## Unreliable packets
+
+Unreliable packets use `UnreliableRemoteEvent`.
+
+```lua
+AimDirection = ByteNetMax.definePacket({
+	value = ByteNetMax.vec3,
+	reliabilityType = "unreliable",
+})
+```
+
+Use unreliable delivery when the newest update matters and an older one can be discarded:
+
+- Aim direction
+- Cosmetic transforms
+- Rapid, replaceable effects
+- Non-authoritative telemetry
+
+Never use unreliable delivery for purchases, damage decisions, inventory changes, or any state transition that must arrive.
+
+## Frame batching
+
+ByteNet Max queues packet writes and flushes its reliable and unreliable channels on `RunService.Heartbeat`. Multiple sends in one frame can share a single transport call.
+
+This means:
+
+- `send` queues a packet; it does not immediately perform a remote call.
+- Bursty traffic in one frame benefits from batching.
+- You should still avoid unnecessary high-frequency sends.
+
+Queries use the query transport and wait for a response; they are not a replacement for packet streams.

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1,0 +1,56 @@
+# Security and limits
+
+ByteNet Max serializes values according to your declared schemas. Your game must still validate meaning and authority.
+
+## Validate every client request
+
+For each client packet or query, verify relevant server-owned facts:
+
+- Is this action allowed right now?
+- Does the player own the item?
+- Is the target close enough?
+- Has the cooldown elapsed?
+- Is the amount within a valid range?
+- Can the player access the requested record?
+
+```lua
+Network.packets.BuyItem.listen(function(Request, Player)
+	local Item = ItemCatalog[Request.ItemId]
+	if not Item then
+		return
+	end
+
+	if not EconomyService:CanAfford(Player, Item.Price) then
+		return
+	end
+
+	EconomyService:Purchase(Player, Request.ItemId)
+end)
+```
+
+Do not accept a price, reward, damage amount, or ownership flag just because it matches the declared data type.
+
+## Inbound buffer limit
+
+The server limits client buffers to the `MAX_BUFFER_SIZE` attribute on the ByteNet Max module. The default is 8,192 bytes. The same value is used as the per-client byte budget and refill rate per second.
+
+Set the attribute before ByteNet Max starts if your experience needs a different limit:
+
+```lua
+ByteNetMaxModule:SetAttribute("MAX_BUFFER_SIZE", 16 * 1024)
+local ByteNetMax = require(ByteNetMaxModule)
+```
+
+Increase this only after measuring a legitimate need. A larger value also permits more client-originated traffic.
+
+## Keep payloads bounded
+
+- Cap user-controlled string lengths before sending or processing them.
+- Limit collection sizes.
+- Prefer IDs over large repeated objects.
+- Avoid sending state the receiver already has.
+- Rate-limit expensive game actions separately from ByteNet Max's byte limiter.
+
+## Keep the server authoritative
+
+The client should request an action. The server should calculate the outcome and notify clients of the result.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,108 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+# Networking that stays understandable
+
+ByteNet Max is a typed, buffer-based networking library for Roblox. Define each message once, share that definition between the server and client, and use **packets** for events or **queries** for request/response calls.
+
+[Build your first packet](getting-started/first-packet.md){ .md-button .md-button--primary }
+[Install ByteNet Max](getting-started/installation.md){ .md-button }
+
+<div class="feature-grid" markdown>
+
+<div class="feature-card" markdown>
+
+## :material-lightning-bolt: Packets
+
+Send one-way messages through reliable or unreliable channels. ByteNet Max batches packet traffic once per frame.
+
+[Learn packets](guides/packets.md)
+
+</div>
+
+<div class="feature-card" markdown>
+
+## :material-swap-horizontal: Queries
+
+Send a typed request from a client and receive a typed response from the server—without manually creating a `RemoteFunction`.
+
+[Learn queries](guides/queries.md)
+
+</div>
+
+<div class="feature-card" markdown>
+
+## :material-code-braces: Shared definitions
+
+Keep packet and query schemas in a shared ModuleScript. The same schema gives both sides a consistent wire format.
+
+[Understand namespaces](api/namespace.md)
+
+</div>
+
+</div>
+
+## The complete shape
+
+```lua title="ReplicatedStorage/Network.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ByteNetMax = require(ReplicatedStorage.Packages.ByteNetMax)
+
+return ByteNetMax.defineNamespace("Game", function()
+	return {
+		packets = {
+		ShowToast = ByteNetMax.definePacket({
+			value = ByteNetMax.struct({
+				Message = ByteNetMax.string,
+			}),
+		}),
+		},
+		queries = {
+			GetCoins = ByteNetMax.defineQuery({
+				request = ByteNetMax.nothing,
+				response = ByteNetMax.uint32,
+			}),
+		},
+	}
+end)
+```
+
+```lua title="ServerScriptService/Network.server.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Network = require(ReplicatedStorage.Network)
+
+Network.queries.GetCoins.listen(function(_, Player)
+	return Player:GetAttribute("Coins") or 0
+end)
+
+Network.packets.ShowToast.sendTo({ Message = "Welcome!" }, game.Players:GetPlayers()[1])
+```
+
+```lua title="StarterPlayerScripts/Network.client.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Network = require(ReplicatedStorage.Network)
+
+Network.packets.ShowToast.listen(function(Data)
+	print(Data.Message)
+end)
+
+local Coins = Network.queries.GetCoins.invoke(nil)
+print(`You have {Coins} coins`)
+```
+
+!!! important "Require the shared definition on both sides"
+    The server and client must both require the same namespace ModuleScript. Put that module somewhere shared, normally `ReplicatedStorage`, and initialize it from a server Script and a LocalScript.
+
+## Pick the right tool
+
+| You need to… | Use | Example |
+| --- | --- | --- |
+| Notify the server or a client | Packet | Equip an item, show an effect |
+| Broadcast to several clients | Packet | Round state, announcement |
+| Send frequent disposable state | Unreliable packet | Aim direction, cosmetic position |
+| Ask the server for a result | Query | Fetch a profile summary |
+
+ByteNet Max is based on [ByteNet](https://github.com/ffrostfall/ByteNet), but this documentation describes **ByteNet Max's current source and API**.

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,1 +1,0 @@
-Docs folder 1 edit 1

--- a/docs/reference/common-mistakes.md
+++ b/docs/reference/common-mistakes.md
@@ -1,0 +1,46 @@
+# Common mistakes
+
+## The client cannot initialize a namespace
+
+**Cause:** The server has not required the shared namespace module, or the client is using a different definition.
+
+**Fix:** Put the definition in `ReplicatedStorage` and require the same ModuleScript during both server and client startup.
+
+## `send` errors on the server
+
+`send` is client-only. From the server, use `sendTo`, `sendToList`, `sendToAll`, or `sendToAllExcept`.
+
+## `sendTo` errors on the client
+
+Server targeting methods are server-only. A client can only send a packet to the server with `send`.
+
+## Arguments to `sendTo` are reversed
+
+Data comes first; the player comes second:
+
+```lua
+Packet.sendTo(Data, Player)
+```
+
+## A query never returns useful data
+
+Confirm that:
+
+1. The server registered a listener.
+2. The listener returns a value.
+3. The return value matches the declared `response` type.
+4. The handler completes promptly.
+
+Use one active server handler per query.
+
+## Values wrap or lose precision
+
+The schema is too narrow. Check numeric ranges and remember that `Color3` uses 8-bit channels while vectors and CFrames use float32 components.
+
+## `disconnectAll` removed another system's listener
+
+`disconnectAll` removes every listener for that packet or query in the current runtime. Keep and call the specific disconnect function returned by `listen` instead.
+
+## The server accepts impossible actions
+
+Data types validate representation, not game rules. Validate all client actions against server-owned state. See [Security and limits](../guides/security.md).

--- a/docs/reference/migration.md
+++ b/docs/reference/migration.md
@@ -1,0 +1,63 @@
+# Migration from ByteNet
+
+ByteNet Max began as a ByteNet fork, but projects should use ByteNet Max's own package and documentation.
+
+## Update the dependency
+
+```toml
+[dependencies]
+ByteNetMax = "elitriare/bytenet-max@0.2.7"
+```
+
+Check the [Wally package](https://wally.run/package/elitriare/bytenet-max) for the current version.
+
+## Update the require
+
+```lua
+local ByteNetMax = require(ReplicatedStorage.Packages.ByteNetMax)
+```
+
+## Keep packet definitions shared
+
+The familiar namespace and packet model remains:
+
+```lua
+ByteNetMax.defineNamespace("Game", function()
+	return {
+		packets = {
+			Example = ByteNetMax.definePacket({
+				value = ByteNetMax.string,
+			}),
+		},
+	}
+end)
+```
+
+Review method signatures against the [packet API](../api/packet.md), especially `sendTo(Data, Player)`.
+
+## Replace manual request/response remotes
+
+ByteNet Max adds queries:
+
+```lua
+GetValue = ByteNetMax.defineQuery({
+	request = ByteNetMax.string,
+	response = ByteNetMax.uint32,
+})
+```
+
+Register the handler on the server with `listen`, then invoke it from the client with `invoke`.
+
+## Review data types
+
+Use the [ByteNet Max data type reference](../api/data-types.md) instead of assuming every upstream codec or API is identical.
+
+## Test both runtime directions
+
+Before shipping, verify:
+
+- Client → server packet
+- Server → client packet
+- Reliable and unreliable traffic you use
+- Query request and response
+- Listener cleanup during player or UI lifecycle changes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,58 +1,116 @@
 site_name: ByteNet Max
-repo_name: elitriare/ByteNet-Max
+site_description: Clear, source-aligned documentation for ByteNet Max networking on Roblox.
+site_url: https://elitriare.github.io/ByteNet-Max/
+repo_name: Elitriare/ByteNet-Max
 repo_url: https://github.com/Elitriare/ByteNet-Max
-
-nav:
-  - Home: index.md
-  - Documentation:
-    - Packets:
-      - definePacket: api/functions/definePacket.md
-    - DataTypes:
-      - Primitives: api/dataTypes/Primitives.md
-      - Specials: api/dataTypes/Specials.md
-
+edit_uri: edit/main/docs/
+copyright: ByteNet Max is available under the MIT License.
 
 theme:
   name: material
-  favicon: assets/favicon.png
-  logo: assets/bytenetLogo.png
+  language: en
   palette:
-    scheme: slate
-    primary: custom
-    accent: white
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Use light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-sunny
+        name: Use dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/weather-night
+        name: Follow system preference
   font:
-    text: Arial
-    code: Fira Code
+    text: Inter
+    code: JetBrains Mono
+  icon:
+    logo: material/connection
+    repo: fontawesome/brands/github
   features:
+    - announce.dismiss
+    - content.action.edit
+    - content.code.annotate
     - content.code.copy
+    - navigation.footer
+    - navigation.indexes
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.path
+    - navigation.sections
     - navigation.tabs
     - navigation.top
-    - navigation.sections
-    - navigation.instant
-    - navigation.indexes
-    - search.suggest
     - search.highlight
-  icon:
-    repo: octicons/mark-github-16
+    - search.share
+    - search.suggest
+    - toc.follow
+
+nav:
+  - Home: index.md
+  - Get started:
+      - Installation: getting-started/installation.md
+      - Your first packet: getting-started/first-packet.md
+      - Your first query: getting-started/first-query.md
+      - Core concepts: getting-started/core-concepts.md
+  - Guides:
+      - Packets: guides/packets.md
+      - Queries: guides/queries.md
+      - Choosing data types: guides/choosing-data-types.md
+      - Reliability and batching: guides/reliability.md
+      - Security and limits: guides/security.md
+  - API:
+      - Overview: api/index.md
+      - defineNamespace: api/namespace.md
+      - definePacket: api/packet.md
+      - defineQuery: api/query.md
+      - Data types: api/data-types.md
+  - Reference:
+      - Common mistakes: reference/common-mistakes.md
+      - Migration from ByteNet: reference/migration.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/Elitriare/ByteNet-Max
+      name: ByteNet Max on GitHub
+  generator: false
 
 extra_css:
-  - css/colors.css
-  - css/codeblocks.css
-  - css/global.css
-  - css/homepage.css
+  - assets/stylesheets/extra.css
 
 markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - admonition
-  - pymdownx.details
-  - pymdownx.extra
   - pymdownx.superfences
-  - attr_list
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,1 @@
+mkdocs-material==9.7.2


### PR DESCRIPTION
## What changed

- replaces the placeholder/broken MkDocs source with a complete ByteNet Max documentation site
- adds beginner walkthroughs for packets and queries
- documents namespaces, packet/query methods, all public data types, reliability, batching, security limits, migration, and common mistakes
- adds responsive Material for MkDocs styling and search
- replaces the outdated README guide with a concise entry point to the dedicated docs
- adds a GitHub Actions workflow that builds and deploys the site to GitHub Pages

## Why

The repository currently points users to the upstream ByteNet documentation, while its own `docs/` directory contains only a placeholder and `mkdocs.yml` references missing pages. This makes ByteNet Max behavior—especially queries and its current API—hard to discover and easy to misunderstand.

## Validation

- `mkdocs build --strict`
- `git diff --check`
- inspected the rendered site at desktop and 390px mobile widths
- checked browser console output for warnings and errors

## Deployment note

After merging, set **Settings → Pages → Build and deployment → Source** to **GitHub Actions**. The workflow will then publish `https://elitriare.github.io/ByteNet-Max/` from `main`.