### PR TITLE
[codex] refine blue docs and initialization guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Check the [Wally package](https://wally.run/package/elitriare/bytenet-max) for t
 
 ## Minimal example
 
+> [!IMPORTANT]
+> The shared namespace ModuleScript must be required on both the server and client, with the server initializing first. See [Required initialization](https://elitriare.github.io/ByteNet-Max/getting-started/initialization/).
+
 Define networking once in a shared ModuleScript:
 
 ```lua

--- a/docs/api/namespace.md
+++ b/docs/api/namespace.md
@@ -39,5 +39,5 @@ end)
 
 The empty tables are optional. A packet-only namespace may omit `queries`, and a query-only namespace may omit `packets`.
 
-!!! important
-    Define a namespace in one shared ModuleScript and require that module on both server and client. Do not maintain two hand-written copies of the schema.
+!!! danger "Both sides are mandatory"
+    Define a namespace in one shared ModuleScript, initialize it on the server first, and require the exact same module on the client. Do not maintain two hand-written copies of the schema. See [Required initialization](../getting-started/initialization.md).

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -1,19 +1,24 @@
 :root {
-  --md-primary-fg-color: #6d5dfc;
-  --md-primary-fg-color--light: #8b7fff;
-  --md-primary-fg-color--dark: #5143d9;
-  --md-accent-fg-color: #8b7fff;
+  --md-primary-fg-color: #2563eb;
+  --md-primary-fg-color--light: #38bdf8;
+  --md-primary-fg-color--dark: #1d4ed8;
+  --md-accent-fg-color: #0ea5e9;
 }
 
 [data-md-color-scheme="slate"] {
-  --md-default-bg-color: #0d1020;
-  --md-default-bg-color--light: #14182b;
-  --md-code-bg-color: #14182b;
-  --md-typeset-a-color: #a59cff;
+  --md-default-bg-color: #07111f;
+  --md-default-bg-color--light: #0d1b2e;
+  --md-code-bg-color: #0d1b2e;
+  --md-typeset-a-color: #60a5fa;
 }
 
 .md-header {
-  background: linear-gradient(90deg, #5143d9, #6d5dfc);
+  background: linear-gradient(100deg, #1d4ed8, #0284c7);
+  box-shadow: 0 1px 0 rgb(255 255 255 / 10%);
+}
+
+.md-tabs {
+  background: linear-gradient(100deg, #1d4ed8, #0284c7);
 }
 
 .md-typeset h1 {
@@ -38,10 +43,17 @@
 }
 
 .feature-card {
-  border: 1px solid var(--md-default-fg-color--lightest);
+  border: 1px solid color-mix(in srgb, var(--md-primary-fg-color) 24%, transparent);
   border-radius: 0.75rem;
   padding: 0.4rem 1rem 0.8rem;
-  background: var(--md-default-bg-color--light);
+  background: color-mix(in srgb, var(--md-primary-fg-color) 5%, var(--md-default-bg-color));
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.feature-card:hover {
+  border-color: color-mix(in srgb, var(--md-primary-fg-color) 60%, transparent);
+  box-shadow: 0 12px 28px rgb(15 76 160 / 12%);
+  transform: translateY(-2px);
 }
 
 .feature-card h2 {
@@ -49,7 +61,42 @@
 }
 
 .md-typeset .md-button {
-  border-radius: 0.45rem;
+  border: 1px solid color-mix(in srgb, var(--md-primary-fg-color) 65%, transparent);
+  border-radius: 999px;
+  box-shadow: 0 4px 14px rgb(37 99 235 / 12%);
+  font-size: 0.76rem;
+  letter-spacing: -0.01em;
+  padding: 0.55em 1.2em;
+  transition: background 160ms ease, border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.md-typeset .md-button--primary {
+  background: linear-gradient(100deg, #2563eb, #0284c7);
+  border-color: transparent;
+}
+
+.md-typeset .md-button:hover {
+  border-color: #38bdf8;
+  box-shadow: 0 8px 22px rgb(37 99 235 / 22%);
+  transform: translateY(-1px);
+}
+
+.critical-setup {
+  background: linear-gradient(110deg, rgb(37 99 235 / 14%), rgb(14 165 233 / 7%));
+  border: 1px solid rgb(56 189 248 / 42%);
+  border-left: 0.25rem solid #38bdf8;
+  border-radius: 0.7rem;
+  margin: 1.4rem 0 2rem;
+  padding: 0.5rem 1.1rem 0.75rem;
+}
+
+.critical-setup h3 {
+  color: var(--md-typeset-a-color);
+  margin: 0.6rem 0 0.25rem;
+}
+
+.critical-setup p {
+  margin: 0.45rem 0;
 }
 
 .md-typeset table:not([class]) th {

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -46,7 +46,7 @@ Explicit types are usually smaller and clearer than `auto`.
 
 ## Shared initialization
 
-The namespace definition must run on both the server and client. Sharing a single ModuleScript prevents the two sides from drifting apart.
+The namespace definition must run on both the server and client, with the server initializing first. Sharing a single ModuleScript prevents the two sides from drifting apart. Follow the [required initialization guide](initialization.md) for the exact layout.
 
 ```mermaid
 flowchart LR
@@ -55,6 +55,8 @@ flowchart LR
     S --> M["Server publishes ID and struct metadata"]
     M --> C
 ```
+
+If a namespace contains packets, its callback must return a `packets` table. If it contains queries, it must return a `queries` table. Return both when the namespace uses both primitives.
 
 ## Server authority
 

--- a/docs/getting-started/first-packet.md
+++ b/docs/getting-started/first-packet.md
@@ -2,6 +2,9 @@
 
 A packet is a one-way message. In this example, the client tells the server which action it requested.
 
+!!! important "Before you start"
+    Complete [Required initialization](initialization.md) first. Your shared namespace module must be required on both the server and client.
+
 ## 1. Define it once
 
 Create a shared ModuleScript:
@@ -24,6 +27,8 @@ end)
 ```
 
 `value` is the packet's schema. Sending anything that does not match this shape can fail during serialization.
+
+Because this packet uses `struct`, send a dictionary whose field names match the schema. `{ Action = "Dash" }` is correct; `{ "Dash" }` is not.
 
 ## 2. Listen on the server
 

--- a/docs/getting-started/first-query.md
+++ b/docs/getting-started/first-query.md
@@ -2,6 +2,9 @@
 
 A query is a client-to-server request that returns a response. Use it when the caller cannot continue without a server result.
 
+!!! important "Before you start"
+    Complete [Required initialization](initialization.md) first. Your shared namespace module must be required on both the server and client.
+
 ## 1. Define request and response types
 
 ```lua title="ReplicatedStorage/Network.luau"

--- a/docs/getting-started/initialization.md
+++ b/docs/getting-started/initialization.md
@@ -1,0 +1,77 @@
+# Required initialization
+
+ByteNet Max must initialize the **same shared namespace module** on both the server and client. This is required before packets or queries can communicate.
+
+!!! danger "Require it twice: once per runtime"
+    A server Script must require your shared namespace module, and a LocalScript must require that same module. The server should initialize first so it can publish the packet, query, and struct mappings that the client reads.
+
+## 1. Keep definitions in `ReplicatedStorage`
+
+```text
+ReplicatedStorage
+├── ByteNetMax
+└── Network.luau
+ServerScriptService
+└── Network.server.luau
+StarterPlayer
+└── StarterPlayerScripts
+    └── Network.client.luau
+```
+
+```lua title="ReplicatedStorage/Network.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ByteNetMax = require(ReplicatedStorage.ByteNetMax)
+
+return ByteNetMax.defineNamespace("Game", function()
+	return {
+		packets = {
+			Ready = ByteNetMax.definePacket({
+				value = ByteNetMax.bool,
+			}),
+		},
+	}
+end)
+```
+
+If the namespace uses packets, return a `packets` table. If it uses queries, return a `queries` table. A namespace can return both.
+
+## 2. Initialize the server
+
+```lua title="ServerScriptService/Network.server.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Network = require(ReplicatedStorage.Network)
+
+Network.packets.Ready.listen(function(IsReady, Player)
+	print(Player.Name, IsReady)
+end)
+```
+
+Run this during server startup—not only after a player performs an action.
+
+## 3. Initialize the client
+
+```lua title="StarterPlayerScripts/Network.client.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Network = require(ReplicatedStorage.Network)
+
+Network.packets.Ready.send(true)
+```
+
+The client reads the metadata established by the server and builds matching local packet/query objects.
+
+## What failure looks like
+
+Missing or mismatched initialization can cause:
+
+- A namespace failing while the client starts
+- An invalid or missing packet/query ID
+- A “no readable entity” error
+- Data being decoded with the wrong schema
+- Networking that works inconsistently because of startup order
+
+When debugging these symptoms, first confirm that the server initializes the shared module, the client requires the exact same instance, and both sides use the same deployed version.
+
+!!! note "What “secure” means here"
+    This setup establishes ByteNet Max's controlled shared network mapping; it is not encryption or authentication. You must still validate all client requests on the server.
+
+[Create your first packet](first-packet.md){ .md-button .md-button--primary }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -53,6 +53,9 @@ StarterPlayer
 
 Both runtime sides must require `Network.luau`. The server should initialize its networking code during startup so namespace metadata exists before the client reads it.
 
+!!! danger "Installation is not complete until both sides initialize"
+    Requiring only the server code or only the client code is not enough. ByteNet Max needs the same shared namespace module on both sides to establish matching network mappings. Follow [Required initialization](initialization.md) before sending anything.
+
 ## Next step
 
-[Create your first packet](first-packet.md){ .md-button .md-button--primary }
+[Set up both runtime sides](initialization.md){ .md-button .md-button--primary }

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,16 @@ ByteNet Max is a typed, buffer-based networking library for Roblox. Define each 
 [Build your first packet](getting-started/first-packet.md){ .md-button .md-button--primary }
 [Install ByteNet Max](getting-started/installation.md){ .md-button }
 
+<div class="critical-setup" markdown>
+
+### :material-connection: Required: initialize on the server **and** client
+
+The same shared namespace ModuleScript must be required by a server Script and a LocalScript. The server should initialize first. Without both sides, ByteNet Max cannot establish matching packet, query, and struct mappings, and networking will fail.
+
+[See the required setup →](getting-started/initialization.md)
+
+</div>
+
 <div class="feature-grid" markdown>
 
 <div class="feature-card" markdown>
@@ -93,8 +103,8 @@ local Coins = Network.queries.GetCoins.invoke(nil)
 print(`You have {Coins} coins`)
 ```
 
-!!! important "Require the shared definition on both sides"
-    The server and client must both require the same namespace ModuleScript. Put that module somewhere shared, normally `ReplicatedStorage`, and initialize it from a server Script and a LocalScript.
+!!! danger "Do not skip network initialization"
+    The server and client must both require the same namespace ModuleScript. Put it in `ReplicatedStorage`, require it from a server Script first, and require it again from a LocalScript. [See the exact setup](getting-started/initialization.md).
 
 ## Pick the right tool
 

--- a/docs/reference/common-mistakes.md
+++ b/docs/reference/common-mistakes.md
@@ -4,7 +4,36 @@
 
 **Cause:** The server has not required the shared namespace module, or the client is using a different definition.
 
-**Fix:** Put the definition in `ReplicatedStorage` and require the same ModuleScript during both server and client startup.
+**Fix:** Put the definition in `ReplicatedStorage`, initialize it on the server first, and require the exact same ModuleScript during client startup. Follow [Required initialization](../getting-started/initialization.md).
+
+## A packet/query ID is invalid or unreadable
+
+This usually indicates one of three problems:
+
+1. The namespace was not initialized on both server and client.
+2. The two runtimes loaded different definitions or package versions.
+3. The payload does not match the declared schema.
+
+Verify shared initialization before debugging individual sends.
+
+## A struct arrives incorrectly
+
+`struct` values are dictionaries, not positional arrays. Match every declared field name:
+
+```lua
+-- Schema
+ByteNetMax.struct({ Message = ByteNetMax.string })
+
+-- Correct
+Packet.send({ Message = "Hello" })
+
+-- Incorrect
+Packet.send({ "Hello" })
+```
+
+## Packets or queries are missing from the namespace
+
+Return a `packets` table when defining packets and a `queries` table when defining queries. Return both when using both.
 
 ## `send` errors on the server
 
@@ -36,6 +65,10 @@ Use one active server handler per query.
 ## Values wrap or lose precision
 
 The schema is too narrow. Check numeric ranges and remember that `Color3` uses 8-bit channels while vectors and CFrames use float32 components.
+
+## Can I send functions?
+
+No. Roblox remotes cannot transmit functions. Send data that identifies the action, then map that identifier to trusted code on the receiving side.
 
 ## `disconnectAll` removed another system's listener
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
   - Home: index.md
   - Get started:
       - Installation: getting-started/installation.md
+      - Required initialization: getting-started/initialization.md
       - Your first packet: getting-started/first-packet.md
       - Your first query: getting-started/first-query.md
       - Core concepts: getting-started/core-concepts.md
@@ -76,6 +77,7 @@ nav:
       - Migration from ByteNet: reference/migration.md
 
 extra:
+  announcement: ByteNet Max must be initialized on both the server and client.
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/Elitriare/ByteNet-Max


### PR DESCRIPTION
## What changed

- replaces the purple palette with a blue/cyan theme
- makes primary and secondary buttons smaller, pill-shaped, and more polished
- adds a prominent initialization callout to the homepage
- adds a dedicated **Required initialization** guide with exact server/client setup
- reinforces that the same namespace ModuleScript must be required on both runtimes, with the server initializing first
- adds DevForum-derived troubleshooting for namespace tables, schema mismatches, struct dictionaries, invalid IDs, and unsupported function payloads

## Why

The server/client initialization requirement is one of the most frequently missed ByteNet Max setup steps. When omitted or mismatched, packet/query IDs and struct mappings cannot be established consistently.

## Validation

- `mkdocs build --strict`
- `git diff --check`
- inspected desktop and 390px mobile layouts
- verified the new initialization page in the rendered navigation and content
- no browser console warnings or errors